### PR TITLE
Fixed some references and code fixes

### DIFF
--- a/bin/azure_monitor_metrics_main.py
+++ b/bin/azure_monitor_metrics_main.py
@@ -220,7 +220,8 @@ def get_metrics_for_subscription(inputs, app_id, app_key, ew):
             'Azure')['activeDirectoryResourceId']
         bearer_token = get_access_token(
             tenant_id,
-            arm_creds['spn_client_id'],
+            #arm_creds['spn_client_id'],
+            spn_client_id,
             arm_creds['spn_client_secret'],
             authentication_endpoint,
             resource)

--- a/bin/subs.py
+++ b/bin/subs.py
@@ -138,7 +138,7 @@ def get_secret_from_keyvault(ew, bearer_token, vault_name, secret_name, secret_v
 
     response_content = response.content
     content = json.loads(response_content)
-    creds = {'spn_client_id': content['contentType'],
+    creds = {#'spn_client_id': content['contentType'],
              'spn_client_secret': content['value']}
 
     return creds

--- a/packages/am_depends_ubuntu.sh
+++ b/packages/am_depends_ubuntu.sh
@@ -10,9 +10,23 @@ pip install cryptography -q
 pip install adal -q
 pip install splunk-sdk -q
 pip install futures -q
-cp $PYTHON_SITEPACKAGES/six.py $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
-cp -R $PYTHON_SITEPACKAGES/splunklib $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
-cp -R $PYTHON_SITEPACKAGES/concurrent $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
-cp -R $PYTHON_SITEPACKAGES/adal $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
-cp -R $PYTHON_SITEPACKAGES/jwt $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
-cp -R $PYTHON_SITEPACKAGES/dateutil $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp $PYTHON_SITEPACKAGES/six.py $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp -R $PYTHON_SITEPACKAGES/splunklib $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp -R $PYTHON_SITEPACKAGES/concurrent $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp -R $PYTHON_SITEPACKAGES/adal $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp -R $PYTHON_SITEPACKAGES/jwt $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+#cp -R $PYTHON_SITEPACKAGES/dateutil $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin
+
+#Commented the lines above as Splunk has its own Python packages default location and the lines below
+cp $PYTHON_SITEPACKAGES/six.py $SPLUNK_HOME/lib/python2.7/site-packages
+cp -R $PYTHON_SITEPACKAGES/splunklib $SPLUNK_HOME/lib/python2.7/site-packages
+cp -R $PYTHON_SITEPACKAGES/concurrent $SPLUNK_HOME/lib/python2.7/site-packages
+cp -R $PYTHON_SITEPACKAGES/adal $SPLUNK_HOME/lib/python2.7/site-packages
+cp -R $PYTHON_SITEPACKAGES/jwt $SPLUNK_HOME/lib/python2.7/site-packages
+cp -R $PYTHON_SITEPACKAGES/dateutil $SPLUNK_HOME/lib/python2.7/site-packages
+
+#Adding the following lines to have the Node.JS packages and modules installed
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+apt-get install -y nodejs
+cd $SPLUNK_HOME/etc/apps/TA-Azure_Monitor/bin/app
+npm install


### PR DESCRIPTION
**Update to azure_monitor_metrics_main.py and subs.py**
The JSON object that is returned from the key vault call does not have an attribute called 'contentType'. Commenting this out and then adding a reference in the azure_monitor_metrics_main.py file where this function is called with spn_client_id resolves most of the error that I see in the splunk log.

**Update to am_depends_ubuntu.sh**

Commented the lines above as Splunk has its own Python packages default location and the lines below. Also adding the following lines to have the Node.JS packages and modules installed.

> These changes are tested on Ubuntu/Debian only.