### PR TITLE
Update azure-setup.ps1

### DIFF
--- a/scripts/azure-setup.ps1
+++ b/scripts/azure-setup.ps1
@@ -91,6 +91,7 @@ $locations += "global"
 $serviceBusRuleId = "/subscriptions/$subscriptionId/resourceGroups/$splunkResourceGroupName" + ` 
                     "/providers/Microsoft.EventHub/namespaces/$eventHubNamespaceName" + `
                     "/authorizationrules/RootManageSharedAccessKey"
+Register-AzureRmResourceProvider -ProviderNamespace Microsoft.Insights
 Remove-AzureRmLogProfile -Name $logProfileName -ErrorAction SilentlyContinue
 Add-AzureRmLogProfile -Name $logProfileName -Location $locations -ServiceBusRuleId $serviceBusRuleId 
 


### PR DESCRIPTION
Register-AzureRmResourceProvider -ProviderNamespace Microsoft.Insights
If the Microsoft.Insights provider has not been registered the script fails at Add-AzureRmLogProfile line with the following...
Add-AzureRmLogProfile : Exception type: CloudException, Message: Please register the subscription 'subscriptionid' with Microsoft.Insights., Code: 
AuthorizationFailed, Status code:Conflict, Reason phrase: Conflict