### PR TITLE
Add insights-logs-signinlogs hub

### DIFF
--- a/bin/app/hubs.json
+++ b/bin/app/hubs.json
@@ -14,6 +14,7 @@
     "insights-logs-jobstreams": "resourceId",
     "insights-logs-audit": "resourceId",
     "insights-logs-signin": "resourceId",
+    "insights-logs-signinlogs": "resourceId",
     "insights-logs-requests": "resourceId",
     "insights-logs-requestlogs": "resourceId",
     "insights-logs-operationallogs": "resourceId",


### PR DESCRIPTION
If no event hub name is specified when creating the diagnostic setting for AAD, then sign-in logs are written to "insights-logs-signinlogs" (at least for my subscription).  Therefore, sign-in data is not collected in this situation.  Adding "insights-logs-signinlogs" to the list of hubs corrects the issue and I see sign-in logs after a Splunk restart.