### PR TITLE
Swap resourceName and resourceType regex

### DIFF
--- a/bin/app/azure_monitor_logs.js
+++ b/bin/app/azure_monitor_logs.js
@@ -357,8 +357,8 @@ var messageHandler = function (name, data, eventWriter) {
         // parse values from resourceId
         subscriptionId = getElement(resourceId, 'SUBSCRIPTIONS\/(.*?)\/');
         resourceGroup = getElement(resourceId, 'SUBSCRIPTIONS\/(?:.*?)\/RESOURCEGROUPS\/(.*?)\/');
-        resourceName = getElement(resourceId, 'PROVIDERS\/(.*?\/.*?)(?:\/)');
-        resourceType = getElement(resourceId, 'PROVIDERS\/(?:.*?\/.*?\/)(.*?)(?:\/|$)');
+        resourceType = getElement(resourceId, 'PROVIDERS\/(.*?\/.*?)(?:\/)');
+        resourceName = getElement(resourceId, 'PROVIDERS\/(?:.*?\/.*?\/)(.*?)(?:\/|$)');
 
         if (activityLog) {
 


### PR DESCRIPTION
The regex extractions used for resourceType and resourceName should be swapped.  
Example before:
resourceType = NETWORKWATCHER_WESTUS
resourceName = MICROSOFT.NETWORK/NETWORKWATCHERS

Example after:
resourceName = NETWORKWATCHER_WESTUS
resourceType = MICROSOFT.NETWORK/NETWORKWATCHERS