### PR TITLE
Linux packaging script will use tar if 7zip not available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 To test changes, you will need to generate a version specific package file that includes your changes, such as `.\packages\TA-Azure_Monitor_1_2_7.spl`.  Follow the steps below to generate the version specific package file.
 
-Note: The scripts use [7-Zip](https://www.7-zip.org/) to build the the file structure and contents.  So, make sure you have this installed on your computer and that `7z` can be run from a command/shell prompt. 
+Note: The Windows script `package.cmd` requires [7-Zip](https://www.7-zip.org/) to build the the file structure and contents.  So, make sure you have this installed on your computer and that `7z` can be run from a command/shell prompt. On Mac and Linux, `package.sh` will use tar if 7-zip is not installed.
 
 1. Open `.\default\app.conf` and bump the **version** property in the **[launcher]** section.
 

--- a/deployment/package.sh
+++ b/deployment/package.sh
@@ -10,11 +10,11 @@ version_folder="${ta_folder}_${version}"
 cd "${0%/*}"
 
 # Clean up any existing packages for this version.
-rm /tmp/$version_folder.spl --force
-rm ../packages/$version_folder.spl --force
+if [ -x /tmp/$version_folder.spl ]; then rm /tmp/$version_folder.spl --force; fi
+if [ -x ../packages/$version_folder.spl ]; then rm ../packages/$version_folder.spl --force; fi
 
 # Create folder structure and file contents to put in package.
-rm $ta_folder --force --recursive
+if [ -x $ta_folder ]; then rm $ta_folder --force --recursive; fi
 mkdir $ta_folder 
 cp -r ../bin $ta_folder
 cp -r ../default $ta_folder
@@ -24,12 +24,15 @@ cp ../LICENSE $ta_folder
 cp ../README.md $ta_folder
 
 # Build the package file for this version
-7z a -ttar /tmp/$version_folder.tar $ta_folder/*
-cp /tmp/$version_folder.tar /tmp/$version_folder.spl
-7z a -tgzip ../packages/$version_folder.spl /tmp/$version_folder.spl
-
-# Clean up temporary working files used for packaging
-rm /tmp/$version_folder.spl
-rm /tmp/$version_folder.tar
+if command -v 7z 2>/dev/null; then
+  7z a -ttar /tmp/$version_folder.tar $ta_folder/*
+  cp /tmp/$version_folder.tar /tmp/$version_folder.spl
+  7z a -tgzip ../packages/$version_folder.spl /tmp/$version_folder.spl
+  # Clean up temporary working files used for packaging
+  rm /tmp/$version_folder.tar
+  rm /tmp/$version_folder.spl
+else
+  tar czf ../packages/$version_folder.spl $ta_folder/
+fi
 
 rm $ta_folder --force --recursive


### PR DESCRIPTION
As 7zip is not typically installed on Unix based OS's I've added some code to fall back to 'tar' if 7z is unavailable. If 7z is available the script should behave as it did before.